### PR TITLE
Ensure symbols config is passed to php-scoper

### DIFF
--- a/config/scoper.inc.php
+++ b/config/scoper.inc.php
@@ -20,8 +20,10 @@ $prefix      = $config['prefix'];
 $source      = $config['source'];
 $destination = $config['destination'];
 
-return customize_php_scoper_config( array(
-	'prefix'                     => $prefix,
+// remove source and destination from the config, as they're not part of php-scoper config
+unset( $config['source'], $config['destination'] );
+
+return customize_php_scoper_config( array_merge( $config, array(
 	'finders'                    => array(
 		Finder::create()
 		      ->files()
@@ -93,4 +95,4 @@ return customize_php_scoper_config( array(
 	'expose-global-constants' => false,
 	'expose-global-classes'   => false,
 	'expose-global-functions' => false,
-) );
+) ) );


### PR DESCRIPTION
## The issue

When defining `wordpress` and `woocommerce` as globals in composer.json, it has no effect other than exposing classes. Namespaces and functions are still prefixed.

Possibly related to #7 ?

**Example composer.json**
```json
  "extra": {
    "wpify-scoper": {
      "prefix": "My\\Plugin",
      "folder": "libs",
      "globals": [
        "wordpress",
        "woocommerce"
      ],
      "composerjson": "composer-libs.json",
      "composerlock": "composer-libs.lock",
      "autorun": true
    }
  },
```

## The cause:

The `Plugin` class _does_ [write the exposed symbols to a config file here](https://github.com/wpify/scoper/blob/6f8ab7091235eca9ed49c1f57d0c205dca013a14/src/Plugin.php#L223-L249). However, the config is not passed to PHP scoper. The config [is loaded](https://github.com/wpify/scoper/blob/6f8ab7091235eca9ed49c1f57d0c205dca013a14/config/scoper.inc.php#L5), but it's not passed to `customize_php_scoper_config()`. Only exposed classes are handled [here](https://github.com/wpify/scoper/blob/6f8ab7091235eca9ed49c1f57d0c205dca013a14/config/scoper.inc.php#L72-L86).

## Proposed fix:

This PR merges the loaded $config with the extra config array generated in `scoper.inc.php`. This ensures that all `expose-namespaces`, etc. are passed to PHP scoper. 